### PR TITLE
Fix README run.sh instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Make sure to run this step prior to executing `eval.sh` or `generate_results.sh`
    - Look at `PRD.md` to understand the business problem
    - Look at `INTERVIEWS.md` to understand the business logic
 2. **Create your implementation**:
-   - Copy `run.sh.template` to `run.sh`
-   - Implement your calculation logic
+   - Create a script named `run.sh`
+   - Implement your calculation logic inside this script
    - Make sure it outputs just the reimbursement amount
 3. **Test your solution**: 
    - Run `./eval.sh` to see how you're doing


### PR DESCRIPTION
## Summary
- update instructions to create `run.sh` directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d01e50a48325b8b393b23fc8c988